### PR TITLE
Update hooks not to use the "check" command

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,15 +1,15 @@
 ---
-- id: buf-check-lint
-  name: 'buf check lint'
-  entry: 'run-buf-check-lint.sh'
+- id: buf-lint
+  name: 'buf lint'
+  entry: 'run-buf-lint.sh'
   language: 'script'
   files: '\.proto$'
   pass_filenames: true
-  description: 'Runs `buf check lint`'
-- id: buf-check-breaking
-  name: 'buf check breaking'
-  entry: 'run-buf-check-breaking.sh'
+  description: 'Runs `buf lint`'
+- id: buf-breaking
+  name: 'buf breaking'
+  entry: 'run-buf-breaking.sh'
   language: 'script'
   files: '\.proto$'
   pass_filenames: true
-  description: 'Runs `buf check breaking`'
+  description: 'Runs `buf breaking`'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - repo: git@github.com:nametake/pre-commit-buf.git
   rev: v1.0.0
   hooks:
-    - id: buf-check-lint
-    - id: buf-check-breaking
+    - id: buf-lint
+    - id: buf-breaking
       args: [.git#branch=master] # required --against-input arg
 ```

--- a/run-buf-breaking.sh
+++ b/run-buf-breaking.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 files=$(echo "${@:2}" | tr ' ' ',')
-buf check breaking --against-input "$1" --file ${files}
+buf breaking --against "$1" --path ${files}

--- a/run-buf-lint.sh
+++ b/run-buf-lint.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 files=$(echo "$@" | tr ' ' ',')
-buf check lint --file ${files}
+buf lint --path ${files}


### PR DESCRIPTION
Fixes errors:
```sh
❯ buf check lint
"buf check lint" has been moved to "buf lint".
```

```sh
❯ buf check breaking
"buf check breaking" has been moved to "buf breaking".
```
 and command line flag changes